### PR TITLE
Enable Vercel + S3 deployment and optional Postgres (Supabase) for job state

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ S3_SECRET_KEY=minio123
 S3_BUCKET=book-translator
 
 # Database / state
-DB_MODE=sqlite                   # sqlite | manifests
+DB_MODE=sqlite                   # sqlite | postgres | manifests
 DB_URL=sqlite+aiosqlite:///./data/app.db
 
 # Limits

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# Global AGENTS.md
+
+Machine-level rules for all agent work.
+
+## Mandatory Learning Capture
+
+Any time an agent learns either:
+
+1. A mistake the agent made, or
+2. A user preference (especially Jason's preferences),
+
+the agent must update this file to record that learning as an explicit, actionable rule.
+
+Do not leave that learning only in chat history.
+
+## Learned Preferences
+
+- Split large refactors into many focused commits instead of leaving them as a single umbrella commit. When Jason asks for a history rewrite, aim for at least 10 logically scoped commits if the change is broad enough to support it.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,67 @@ Refer to `BOOK_TRANSLATOR_PROJECT.md` for the roadmap.
 - **Spacing effects:** Exported decks can be scheduled with spaced-repetition algorithms, leveraging the Ebbinghaus forgetting-curve research to retain vocabulary longer.
 - **Context-rich examples:** Long-form text preserves idioms and discourse markers that sentence-level flashcards often strip away, which helps learners internalize natural syntax.
 
+## Vercel + S3 + Supabase (Recommended Deployment)
+
+This repo is now structured so you can run production with:
+
+- **Vercel project #1 (frontend):** `frontend/`
+- **Vercel project #2 (API):** `backend/` (FastAPI serverless function)
+- **S3 bucket:** uploads + artifacts
+- **Supabase Postgres (recommended):** durable job status and metadata
+
+> You can still use `DB_MODE=manifests` for ultra-lean demos, but Supabase is strongly recommended for Vercel because local filesystem state is ephemeral.
+
+### 1) Create cloud resources
+
+1. Create an S3 bucket (for example `book-translator-prod`).
+2. Create a Supabase project and copy the Postgres connection string.
+3. Generate API keys for your translation provider (OpenAI and/or HF).
+
+### 2) Deploy API on Vercel
+
+Set Vercel project root to `backend/` and configure these environment variables:
+
+```bash
+STORAGE_BACKEND=s3
+S3_BUCKET=book-translator-prod
+S3_ENDPOINT=https://s3.amazonaws.com
+S3_ACCESS_KEY=...
+S3_SECRET_KEY=...
+
+DB_MODE=postgres
+DB_URL=postgresql+asyncpg://postgres:<password>@<host>:5432/postgres
+
+TRANSLATOR_PROVIDER=openai
+OPENAI_API_KEY=...
+
+CORS_ALLOW_ORIGINS=https://<your-frontend-domain>
+TARGET_LANGS=es,fr,de,it,pt
+```
+
+After deploy, verify:
+
+```bash
+https://<your-api-domain>/healthz
+```
+
+### 3) Deploy Frontend on Vercel
+
+Set Vercel project root to `frontend/` and set:
+
+```bash
+NEXT_PUBLIC_API_BASE=https://<your-api-domain>
+```
+
+The frontend rewrite sends `/api/*` requests to your backend base URL.
+
+### 4) Validate end-to-end
+
+1. Open the frontend domain.
+2. Upload a small PDF.
+3. Poll job page updates until `done`.
+4. Download EPUB and flashcards.
+
 ## Quick Start (Docker Compose)
 
 Prerequisites: Docker Engine + Docker Compose plugin.

--- a/backend/api/index.py
+++ b/backend/api/index.py
@@ -1,0 +1,5 @@
+"""Vercel entrypoint exposing the FastAPI app."""
+
+from app.main import app
+
+__all__ = ("app",)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -28,7 +28,9 @@ class Settings(BaseSettings):
     s3_secret_key: str | None = Field(default=None, alias="S3_SECRET_KEY")
     s3_bucket: str = Field(default="book-translator", alias="S3_BUCKET")
 
-    db_mode: Literal["sqlite", "manifests"] = Field(default="sqlite", alias="DB_MODE")
+    db_mode: Literal["sqlite", "postgres", "manifests"] = Field(
+        default="sqlite", alias="DB_MODE"
+    )
     db_url: str = Field(default="sqlite+aiosqlite:///./data/app.db", alias="DB_URL")
 
     max_pdf_mb: int = Field(default=100, alias="MAX_PDF_MB")

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -22,11 +22,11 @@ _schema_initialized: bool = False
 
 
 def _ensure_engine() -> None:
-    """Lazy-create the SQLAlchemy engine when running in sqlite mode."""
+    """Lazy-create the SQLAlchemy engine when running in relational DB modes."""
     global _engine, _session_factory  # noqa: PLW0603 (module-level cache)
 
     settings = get_settings()
-    if settings.db_mode != "sqlite":
+    if settings.db_mode not in {"sqlite", "postgres"}:
         return
 
     if _engine is None:
@@ -35,11 +35,11 @@ def _ensure_engine() -> None:
 
 
 async def ensure_schema() -> None:
-    """Create database tables once when running in sqlite mode."""
+    """Create database tables once when running in relational DB modes."""
     global _schema_initialized  # noqa: PLW0603
 
     settings = get_settings()
-    if settings.db_mode != "sqlite" or _schema_initialized:
+    if settings.db_mode not in {"sqlite", "postgres"} or _schema_initialized:
         return
 
     _ensure_engine()
@@ -53,10 +53,10 @@ async def ensure_schema() -> None:
 
 @asynccontextmanager
 async def get_session() -> AsyncIterator[AsyncSession]:
-    """Yield an async SQLAlchemy session when the service is configured for SQLite."""
+    """Yield an async SQLAlchemy session when the service uses a relational DB."""
     settings = get_settings()
-    if settings.db_mode != "sqlite":
-        raise RuntimeError("Database sessions are only available in sqlite mode")
+    if settings.db_mode not in {"sqlite", "postgres"}:
+        raise RuntimeError("Database sessions are only available in relational DB modes")
 
     _ensure_engine()
     assert _session_factory is not None  # nosec - guarded by _ensure_engine

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-"""SQLAlchemy models used when the app runs in sqlite mode."""
+"""SQLAlchemy models used when the app runs in relational DB modes."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ Base = declarative_base()
 
 
 class Job(Base):
-    """Translation job metadata persisted in SQLite."""
+    """Translation job metadata persisted in SQLAlchemy-backed storage."""
 
     __tablename__ = "jobs"
 

--- a/backend/app/pipeline/__init__.py
+++ b/backend/app/pipeline/__init__.py
@@ -34,6 +34,11 @@ class PipelineContext:
 _SENTINEL = object()
 
 
+def _uses_relational_db(settings: Settings) -> bool:
+    """Return whether job metadata is stored in SQLAlchemy-backed storage."""
+    return settings.db_mode in {"sqlite", "postgres"}
+
+
 async def _update_job_state(
     job_id: str,
     *,
@@ -48,7 +53,7 @@ async def _update_job_state(
     """Persist stage/status updates on the configured backend."""
     settings = get_settings()
 
-    if settings.db_mode == "sqlite":
+    if _uses_relational_db(settings):
         async with get_session() as session:
             job = await session.get(Job, job_id)
             if job is None:
@@ -421,7 +426,7 @@ async def run_pipeline(context: PipelineContext) -> None:
         if tmp_dir:
             shutil.rmtree(tmp_dir, ignore_errors=True)
 
-    if settings.db_mode not in {"sqlite", "manifests"}:
+    if settings.db_mode not in {"sqlite", "postgres", "manifests"}:
         raise RuntimeError(f"Unsupported db mode '{settings.db_mode}'")
 
 

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -20,6 +20,11 @@ from .storage.s3_compat import S3Config, S3Storage
 router = APIRouter(tags=["jobs"])
 
 
+def _uses_relational_db(settings: Settings) -> bool:
+    """Return whether job metadata is stored in SQLAlchemy-backed storage."""
+    return settings.db_mode in {"sqlite", "postgres"}
+
+
 class JobStatusResponse(BaseModel):
     """API response schema for job status information."""
 
@@ -129,7 +134,7 @@ async def read_job(job_id: str) -> JobStatusResponse:
     """Return the current status for a translation job."""
     settings = get_settings()
 
-    if settings.db_mode == "sqlite":
+    if _uses_relational_db(settings):
         await ensure_schema()
         async with get_session() as session:
             job = await session.get(Job, job_id)
@@ -172,7 +177,7 @@ async def download_artifact(job_id: str, file_type: str = "epub") -> StreamingRe
             status_code=400, detail=f"Unsupported artifact type '{file_type}'"
         )
 
-    if settings.db_mode == "sqlite":
+    if _uses_relational_db(settings):
         await ensure_schema()
         async with get_session() as session:
             job = await session.get(Job, job_id)
@@ -251,7 +256,7 @@ async def _persist_initial_job(
     source_location: str,
 ) -> JobStatusResponse:
     """Record the initial job state using the configured persistence backend."""
-    if settings.db_mode == "sqlite":
+    if _uses_relational_db(settings):
         await ensure_schema()
         async with get_session() as session:
             job = Job(

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "pydantic-settings>=2.3",
   "sqlalchemy>=2.0",
   "aiosqlite",
+  "asyncpg",
   "boto3",
   "pymupdf",
   "jinja2",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,6 +4,7 @@ pydantic>=2.7
 pydantic-settings>=2.3
 sqlalchemy>=2.0
 aiosqlite
+asyncpg
 boto3
 pymupdf
 jinja2

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -42,3 +42,4 @@ def _reset_db_state(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(db_module, "_engine", None, raising=False)
     monkeypatch.setattr(db_module, "_session_factory", None, raising=False)
+    monkeypatch.setattr(db_module, "_schema_initialized", False, raising=False)

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -13,3 +13,17 @@ def test_settings_default_values(monkeypatch) -> None:
     assert settings.max_pages == 600
     assert settings.target_langs == ["es", "fr", "de", "it", "pt"]
 
+
+def test_settings_support_postgres_db_mode(monkeypatch) -> None:
+    monkeypatch.setenv("DB_MODE", "postgres")
+    monkeypatch.setenv(
+        "DB_URL",
+        "postgresql+asyncpg://postgres:password@example.com:5432/postgres",
+    )
+
+    settings = get_settings()
+
+    assert settings.db_mode == "postgres"
+    assert settings.db_url == (
+        "postgresql+asyncpg://postgres:password@example.com:5432/postgres"
+    )

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -17,7 +17,7 @@ def test_manifest_path_creates_directory(tmp_path, monkeypatch) -> None:
     assert path.name == "job99.json"
 
 
-def test_ensure_engine_skips_when_not_sqlite(monkeypatch) -> None:
+def test_ensure_engine_skips_when_not_relational(monkeypatch) -> None:
     monkeypatch.setattr(db, "get_settings", lambda: SimpleNamespace(db_mode="manifests"))
     monkeypatch.setattr(db, "create_async_engine", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError))
     monkeypatch.setattr(db, "_engine", None, raising=False)
@@ -29,8 +29,15 @@ def test_ensure_engine_skips_when_not_sqlite(monkeypatch) -> None:
     assert db._session_factory is None
 
 
+@pytest.mark.parametrize(
+    ("db_mode", "db_url"),
+    [
+        ("sqlite", "sqlite+aiosqlite:///./data/test.db"),
+        ("postgres", "postgresql+asyncpg://postgres:password@example.com:5432/postgres"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_ensure_schema_initializes_engine(monkeypatch) -> None:
+async def test_ensure_schema_initializes_engine(monkeypatch, db_mode: str, db_url: str) -> None:
     class _DummyBegin:
         def __init__(self) -> None:
             self.ran_sync = False
@@ -64,7 +71,7 @@ async def test_ensure_schema_initializes_engine(monkeypatch) -> None:
     monkeypatch.setattr(
         db,
         "get_settings",
-        lambda: SimpleNamespace(db_mode="sqlite", db_url="sqlite+aiosqlite:///./data/test.db"),
+        lambda: SimpleNamespace(db_mode=db_mode, db_url=db_url),
     )
     monkeypatch.setattr(db, "create_async_engine", lambda *args, **kwargs: dummy_engine)
     monkeypatch.setattr(db, "async_sessionmaker", lambda *args, **kwargs: _DummyFactory())
@@ -93,7 +100,7 @@ async def test_get_session_yields_async_session(tmp_path, monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_session_errors_when_not_sqlite(monkeypatch) -> None:
+async def test_get_session_errors_when_not_relational(monkeypatch) -> None:
     monkeypatch.setattr(db, "get_settings", lambda: SimpleNamespace(db_mode="manifests"))
 
     with pytest.raises(RuntimeError):
@@ -101,8 +108,17 @@ async def test_get_session_errors_when_not_sqlite(monkeypatch) -> None:
             pass
 
 
+@pytest.mark.parametrize(
+    ("db_mode", "db_url"),
+    [
+        ("sqlite", "sqlite+aiosqlite:///./data/test.db"),
+        ("postgres", "postgresql+asyncpg://postgres:password@example.com:5432/postgres"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_get_session_uses_stub_factory(monkeypatch) -> None:
+async def test_get_session_uses_stub_factory(
+    monkeypatch, db_mode: str, db_url: str
+) -> None:
     class _DummySession:
         def __init__(self) -> None:
             self.closed = False
@@ -119,7 +135,7 @@ async def test_get_session_uses_stub_factory(monkeypatch) -> None:
     monkeypatch.setattr(
         db,
         "get_settings",
-        lambda: SimpleNamespace(db_mode="sqlite", db_url="sqlite+aiosqlite:///./data/test.db"),
+        lambda: SimpleNamespace(db_mode=db_mode, db_url=db_url),
     )
     monkeypatch.setattr(db, "create_async_engine", lambda *args, **kwargs: dummy_engine)
     monkeypatch.setattr(db, "async_sessionmaker", lambda *args, **kwargs: _DummyFactory())

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -55,8 +55,9 @@ def test_get_storage_rejects_unknown_backend() -> None:
         _get_storage(settings)
 
 
+@pytest.mark.parametrize("db_mode", ["sqlite", "postgres"])
 @pytest.mark.asyncio
-async def test_persist_initial_job_sqlite(monkeypatch) -> None:
+async def test_persist_initial_job_relational_db(monkeypatch, db_mode: str) -> None:
     class _Session:
         def __init__(self) -> None:
             self.added = None
@@ -80,7 +81,7 @@ async def test_persist_initial_job_sqlite(monkeypatch) -> None:
     monkeypatch.setattr("app.routes.get_session", _get_session)
     monkeypatch.setattr("app.routes.ensure_schema", _ensure_schema)
 
-    settings = SimpleNamespace(db_mode="sqlite")
+    settings = SimpleNamespace(db_mode=db_mode)
     response = await _persist_initial_job(
         settings=settings,
         job_id="job1",

--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -1,0 +1,19 @@
+{
+  "functions": {
+    "api/index.py": {
+      "runtime": "python3.12",
+      "maxDuration": 300,
+      "memory": 3008
+    }
+  },
+  "routes": [
+    {
+      "src": "/healthz",
+      "dest": "api/index.py"
+    },
+    {
+      "src": "/api/(.*)",
+      "dest": "api/index.py"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Make the project deployable on Vercel as a serverless API while using S3 for uploads/artifacts and an optional managed Postgres (e.g., Supabase) for durable job metadata.
- Preserve existing local and `manifests` modes for dev/POC while adding a cloud-friendly `postgres` mode for production on Vercel.

### Description
- Added a Vercel function entrypoint at `backend/api/index.py` and a `backend/vercel.json` function config so the FastAPI app can be deployed as a Vercel Python function, and routed for `/api/*` and `/healthz`.
- Extended settings to support `DB_MODE=postgres` and updated `.env.example` and `README.md` with a `Vercel + S3 + Supabase` deployment guide and environment variable examples (`DB_MODE=postgres`, `DB_URL=postgresql+asyncpg://...`).
- Unified relational DB handling so `sqlite` and `postgres` are treated as relational modes: updated `backend/app/db.py` to initialize the SQLAlchemy engine for relational modes and adjusted `ensure_schema` / `get_session` accordingly.
- Updated API and pipeline code to treat relational DB modes uniformly by adding `_uses_relational_db(...)` checks in `backend/app/routes.py` and `backend/app/pipeline/__init__.py` so job creation, state updates, status reads, and artifact downloads work with Postgres as they do with SQLite.
- Added `asyncpg` to `backend/requirements.txt` to support async Postgres connections and kept existing `aiosqlite` for local SQLite.
- Documentation and examples updated to show how to deploy the frontend and API to Vercel, configure S3, and optionally use Supabase Postgres for durable state.

### Testing
- Ran `python -m compileall backend/app backend/api` which succeeded and verified modules compile.
- Ran `pytest tests/test_config.py tests/test_db.py tests/test_routes.py -q` in the environment; non-async tests passed but async tests failed because the test environment lacked an async pytest plugin (e.g., `pytest-asyncio`), producing 5 failing async-related tests; this is an environment limitation rather than application logic failure.
- Manual smoke checks: configuration and doc edits validated by inspecting `README.md`, `backend/vercel.json`, and `backend/api/index.py` (no runtime execution in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d0a2b7da7c832c86e3de4963b29c57)