### PR TITLE
[codex] Optimize workflow job status updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,5 @@ https://<your-domain>/api/healthz
 
 - `POST /api/jobs` validates file type, file size, blob path, and target language before inserting a job.
 - Page-count, encrypted-PDF, and image-only checks run inside the `parse_pdf` workflow stage so job creation stays fast and does not re-read the uploaded PDF twice.
+- Workflow stage progress updates intentionally use a single `UPDATE ... RETURNING` write in `lib/jobs.ts`; avoid reintroducing a read-before-write query on that hot path.
 - The legacy `backend/` and `frontend/` directories are no longer part of the runtime path.

--- a/docs/testing/test_plan.md
+++ b/docs/testing/test_plan.md
@@ -31,6 +31,7 @@
 ## 6. Coverage and Quality Targets
 - **Coverage:** Grow Vitest coverage around `lib/` and route handlers as the migration stabilizes.
 - **Performance:** `POST /api/jobs` should stay fast because queue publication is the only long-running work in the request path.
+- **Performance:** workflow progress/status patches should stay single-write at the database layer so stage updates do not add an avoidable read-before-write round-trip.
 - **Reliability:** Tests cover invalid upload metadata, encrypted/image-only PDFs, and duplicate queue delivery.
 - **Contract stability:** polling and download responses stay backward-compatible with the previous UI contract.
 

--- a/lib/jobs.ts
+++ b/lib/jobs.ts
@@ -128,29 +128,29 @@ export async function getJobRecord(jobId: string): Promise<JobRow | null> {
 export async function updateJobRecord(jobId: string, patch: JobUpdate): Promise<JobRow | null> {
   await ensureJobsTable()
   const sql = getSql()
-  const current = await getJobRecord(jobId)
-  if (!current) {
-    return null
-  }
-
+  // Workflow progress updates are on the hot path, so keep them to one round-trip.
   const [row] = await sql<Record<string, unknown>[]>`
     update jobs
     set
-      status = ${patch.status !== undefined ? patch.status : current.status},
-      stage = ${patch.stage !== undefined ? patch.stage : current.stage},
-      pct = ${patch.pct !== undefined ? patch.pct : current.pct},
-      error = ${patch.error !== undefined ? patch.error : current.error},
-      workflow_run_id = ${
-        patch.workflowRunId !== undefined ? patch.workflowRunId : current.workflow_run_id
-      },
-      epub_blob_path = ${
-        patch.epubBlobPath !== undefined ? patch.epubBlobPath : current.epub_blob_path
-      },
-      flashcards_blob_path = ${
-        patch.flashcardsBlobPath !== undefined
-          ? patch.flashcardsBlobPath
-          : current.flashcards_blob_path
-      },
+      status = case when ${patch.status !== undefined} then ${patch.status ?? null} else status end,
+      stage = case when ${patch.stage !== undefined} then ${patch.stage ?? null} else stage end,
+      pct = case when ${patch.pct !== undefined} then ${patch.pct ?? null} else pct end,
+      error = case when ${patch.error !== undefined} then ${patch.error ?? null} else error end,
+      workflow_run_id = case
+        when ${patch.workflowRunId !== undefined}
+          then ${patch.workflowRunId ?? null}
+        else workflow_run_id
+      end,
+      epub_blob_path = case
+        when ${patch.epubBlobPath !== undefined}
+          then ${patch.epubBlobPath ?? null}
+        else epub_blob_path
+      end,
+      flashcards_blob_path = case
+        when ${patch.flashcardsBlobPath !== undefined}
+          then ${patch.flashcardsBlobPath ?? null}
+        else flashcards_blob_path
+      end,
       updated_at = now()
     where id = ${jobId}
     returning *

--- a/tests/jobs.test.ts
+++ b/tests/jobs.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type JobRecord = {
+  id: string
+  filename: string
+  source_blob_path: string
+  target_lang: string
+  provider: string
+  status: string
+  stage: string
+  pct: number
+  error: string | null
+  workflow_run_id: string | null
+  epub_blob_path: string | null
+  flashcards_blob_path: string | null
+  created_at: Date
+  updated_at: Date
+}
+
+const state = {
+  queries: [] as string[],
+  rows: new Map<string, JobRecord>(),
+}
+
+function normalizeQuery(strings: TemplateStringsArray) {
+  return strings.join('?').replace(/\s+/g, ' ').trim()
+}
+
+function sqlStub(strings: TemplateStringsArray, ...values: unknown[]) {
+  const query = normalizeQuery(strings)
+  state.queries.push(query)
+
+  if (query.startsWith('create table if not exists jobs')) {
+    return Promise.resolve([])
+  }
+
+  if (query.startsWith('insert into jobs')) {
+    const now = new Date('2026-01-01T00:00:00.000Z')
+    const row: JobRecord = {
+      id: String(values[0]),
+      filename: String(values[1]),
+      source_blob_path: String(values[2]),
+      target_lang: String(values[3]),
+      provider: String(values[4]),
+      status: 'queued',
+      stage: 'queued',
+      pct: 0,
+      error: null,
+      workflow_run_id: null,
+      epub_blob_path: null,
+      flashcards_blob_path: null,
+      created_at: now,
+      updated_at: now,
+    }
+    state.rows.set(row.id, row)
+    return Promise.resolve([row])
+  }
+
+  if (query.startsWith('select * from jobs where id = ?')) {
+    const row = state.rows.get(String(values[0]))
+    return Promise.resolve(row ? [row] : [])
+  }
+
+  if (query.startsWith('update jobs set workflow_run_id = \'__starting__\'')) {
+    const row = state.rows.get(String(values[0]))
+    if (!row || row.workflow_run_id !== null) {
+      return Promise.resolve([])
+    }
+
+    const updated: JobRecord = {
+      ...row,
+      workflow_run_id: '__starting__',
+      updated_at: new Date('2026-01-01T00:00:01.000Z'),
+    }
+    state.rows.set(updated.id, updated)
+    return Promise.resolve([updated])
+  }
+
+  if (query.startsWith('update jobs set status = case when ? then ? else status end,')) {
+    const row = state.rows.get(String(values[14]))
+    if (!row) {
+      return Promise.resolve([])
+    }
+
+    const updated: JobRecord = {
+      ...row,
+      status: values[0] ? String(values[1]) : row.status,
+      stage: values[2] ? String(values[3]) : row.stage,
+      pct: values[4] ? Number(values[5]) : row.pct,
+      error: values[6] ? (values[7] === null ? null : String(values[7])) : row.error,
+      workflow_run_id: values[8]
+        ? (values[9] === null ? null : String(values[9]))
+        : row.workflow_run_id,
+      epub_blob_path: values[10]
+        ? (values[11] === null ? null : String(values[11]))
+        : row.epub_blob_path,
+      flashcards_blob_path: values[12]
+        ? (values[13] === null ? null : String(values[13]))
+        : row.flashcards_blob_path,
+      updated_at: new Date('2026-01-01T00:00:02.000Z'),
+    }
+    state.rows.set(updated.id, updated)
+    return Promise.resolve([updated])
+  }
+
+  throw new Error(`Unhandled query in test stub: ${query}`)
+}
+
+vi.mock('postgres', () => ({
+  default: vi.fn(() => sqlStub),
+}))
+
+async function loadJobsModule() {
+  vi.resetModules()
+  process.env.DATABASE_URL = 'postgres://example.test/kindle'
+  return import('../lib/jobs')
+}
+
+beforeEach(() => {
+  state.queries = []
+  state.rows = new Map()
+})
+
+afterEach(() => {
+  delete process.env.DATABASE_URL
+})
+
+describe('updateJobRecord', () => {
+  it('updates a row without an extra read-before-write query', async () => {
+    const { createJobRecord, updateJobRecord } = await loadJobsModule()
+
+    await createJobRecord({
+      id: 'job_1',
+      filename: 'sample.pdf',
+      sourceBlobPath: 'source/sample.pdf',
+      targetLang: 'es',
+      provider: 'openai',
+    })
+
+    state.queries = []
+
+    const updated = await updateJobRecord('job_1', {
+      stage: 'translate',
+      pct: 35,
+      workflowRunId: 'run_123',
+    })
+
+    expect(updated?.status).toBe('queued')
+    expect(updated?.stage).toBe('translate')
+    expect(updated?.pct).toBe(35)
+    expect(updated?.workflow_run_id).toBe('run_123')
+    expect(state.queries.filter((query) => query.startsWith('select * from jobs'))).toHaveLength(0)
+    expect(state.queries.filter((query) => query.startsWith('update jobs set'))).toHaveLength(1)
+  })
+
+  it('preserves omitted fields but still clears nullable columns explicitly set to null', async () => {
+    const { createJobRecord, updateJobRecord } = await loadJobsModule()
+
+    await createJobRecord({
+      id: 'job_2',
+      filename: 'sample.pdf',
+      sourceBlobPath: 'source/sample.pdf',
+      targetLang: 'fr',
+      provider: 'hf',
+    })
+
+    await updateJobRecord('job_2', {
+      error: 'temporary failure',
+      workflowRunId: 'run_456',
+      epubBlobPath: 'artifacts/sample.epub',
+    })
+
+    const cleared = await updateJobRecord('job_2', {
+      error: null,
+      workflowRunId: null,
+    })
+
+    expect(cleared?.error).toBeNull()
+    expect(cleared?.workflow_run_id).toBeNull()
+    expect(cleared?.epub_blob_path).toBe('artifacts/sample.epub')
+    expect(cleared?.flashcards_blob_path).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- collapse `lib/jobs.ts` job patches from a read-then-write flow into a single `UPDATE ... RETURNING` query
- add a focused Vitest stub around the job store to preserve `undefined` vs explicit `null` patch behavior
- document the single-write expectation in the README and test plan so future workflow changes keep the hot path lean

## Why
Workflow progress updates happen repeatedly during every translation run. The previous implementation fetched the current row before every update, which doubled the database round-trips for each stage transition without changing the final result.

## Impact
This keeps job status/progress updates behaviorally equivalent while removing one avoidable Postgres query from each workflow patch.

## Validation
- `npm test`
- `npm run build`
