### PR TITLE
[codex] Reuse flashcard tokenizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,5 @@ https://<your-domain>/api/healthz
 
 - `POST /api/jobs` validates file type, file size, blob path, and target language before inserting a job.
 - Page-count, encrypted-PDF, and image-only checks run inside the `parse_pdf` workflow stage so job creation stays fast and does not re-read the uploaded PDF twice.
+- Flashcard term extraction reuses one `Intl.Segmenter` and stopword set per language, so long books do not rebuild the same tokenizer helpers for every paragraph during the final workflow stage.
 - The legacy `backend/` and `frontend/` directories are no longer part of the runtime path.

--- a/docs/testing/test_plan.md
+++ b/docs/testing/test_plan.md
@@ -8,14 +8,14 @@
 ## 2. Requirements Coverage Matrix
 | Requirement | Tests | Level |
 | Upload metadata validation | `tests/validation.test.ts` | Unit |
-| Flashcard CSV generation | `tests/flashcards.test.ts` | Unit |
+| Flashcard CSV generation and tokenizer reuse | `tests/flashcards.test.ts` | Unit |
 | PDF extraction cleanup and limits | `lib/pdf.ts` targeted unit tests | Unit |
 | Queue consumer idempotence | route/service tests with mocked `workflow/api` | Unit |
 | Job routes preserve polling/download contract | Next route tests with mocked Blob/Postgres | Integration |
 | Queue → workflow → artifact flow | end-to-end smoke on Vercel or local tunnel setup | E2E |
 
 ## 3. Test Levels and Strategy
-- **Unit tests:** validation, token/term selection helpers, provider adapters, and PDF cleanup logic.
+- **Unit tests:** validation, token/term selection helpers, tokenizer reuse, provider adapters, and PDF cleanup logic.
 - **Integration tests:** route handlers with mocked Blob, Queue, Workflow, and Postgres dependencies.
 - **System checks (manual):** one client upload to Blob, one queued job, one successful workflow completion, and both downloads.
 
@@ -30,7 +30,7 @@
 
 ## 6. Coverage and Quality Targets
 - **Coverage:** Grow Vitest coverage around `lib/` and route handlers as the migration stabilizes.
-- **Performance:** `POST /api/jobs` should stay fast because queue publication is the only long-running work in the request path.
+- **Performance:** `POST /api/jobs` should stay fast because queue publication is the only long-running work in the request path, and flashcard generation should reuse per-language tokenization helpers instead of reallocating them for every paragraph in large books.
 - **Reliability:** Tests cover invalid upload metadata, encrypted/image-only PDFs, and duplicate queue delivery.
 - **Contract stability:** polling and download responses stay backward-compatible with the previous UI contract.
 

--- a/lib/flashcards.ts
+++ b/lib/flashcards.ts
@@ -12,22 +12,42 @@ const STOPWORD_MAP: Record<string, string[]> = {
   pt: stopword.por,
 }
 
+type LanguageTools = {
+  segmenter: Intl.Segmenter
+  stopwords: ReadonlySet<string>
+}
+
+const languageToolsCache = new Map<string, LanguageTools>()
+
 function csvEscape(value: string): string {
   return `"${value.replace(/"/g, '""')}"`
 }
 
-function extractWords(text: string, lang: string): string[] {
-  const segmenter = new Intl.Segmenter(lang, { granularity: 'word' })
-  const stopwords = new Set(STOPWORD_MAP[lang] ?? stopword.eng)
+function getLanguageTools(language: string): LanguageTools {
+  const normalizedLanguage = language.toLowerCase()
+  const cached = languageToolsCache.get(normalizedLanguage)
+  if (cached) {
+    return cached
+  }
+
+  const tools: LanguageTools = {
+    segmenter: new Intl.Segmenter(normalizedLanguage, { granularity: 'word' }),
+    stopwords: new Set(STOPWORD_MAP[normalizedLanguage] ?? stopword.eng),
+  }
+  languageToolsCache.set(normalizedLanguage, tools)
+  return tools
+}
+
+function extractWords(text: string, tools: LanguageTools): string[] {
   const words: string[] = []
 
-  for (const segment of segmenter.segment(text)) {
+  for (const segment of tools.segmenter.segment(text)) {
     if (!segment.isWordLike) {
       continue
     }
 
     const word = segment.segment.toLowerCase().trim()
-    if (word.length < 3 || /\d/.test(word) || stopwords.has(word)) {
+    if (word.length < 3 || /\d/.test(word) || tools.stopwords.has(word)) {
       continue
     }
 
@@ -44,9 +64,12 @@ export async function buildFlashcardsCsv(
 ): Promise<string> {
   const counts = new Map<string, number>()
   const config = getConfig()
+  // Flashcard generation can scan thousands of paragraphs from one book. Reuse
+  // the per-language tokenizer state so the hot path stays focused on the text.
+  const languageTools = getLanguageTools(language)
 
   for (const paragraph of paragraphs) {
-    for (const word of extractWords(paragraph, language)) {
+    for (const word of extractWords(paragraph, languageTools)) {
       counts.set(word, (counts.get(word) ?? 0) + 1)
     }
   }

--- a/tests/flashcards.test.ts
+++ b/tests/flashcards.test.ts
@@ -1,14 +1,25 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+const OriginalSegmenter = Intl.Segmenter
+
+async function loadFlashcardsModule() {
+  vi.resetModules()
+  return import('../lib/flashcards')
+}
+
 afterEach(() => {
   delete process.env.MAX_FLASHCARDS
+  Object.defineProperty(Intl, 'Segmenter', {
+    configurable: true,
+    writable: true,
+    value: OriginalSegmenter,
+  })
 })
 
 describe('buildFlashcardsCsv', () => {
   it('creates a csv with translated high-frequency terms', async () => {
     process.env.MAX_FLASHCARDS = '2'
-    vi.resetModules()
-    const { buildFlashcardsCsv } = await import('../lib/flashcards')
+    const { buildFlashcardsCsv } = await loadFlashcardsModule()
 
     const csv = await buildFlashcardsCsv(
       [
@@ -25,5 +36,40 @@ describe('buildFlashcardsCsv', () => {
     expect(csv).toContain('word,translation')
     expect(csv).toContain('"hola","en:hola"')
     expect(csv).toContain('"casa","en:casa"')
+  })
+
+  it('reuses one segmenter while scanning multiple paragraphs in the same language', async () => {
+    process.env.MAX_FLASHCARDS = '3'
+
+    let segmenterCreations = 0
+    class CountingSegmenter extends OriginalSegmenter {
+      constructor(...args: ConstructorParameters<typeof Intl.Segmenter>) {
+        super(...args)
+        segmenterCreations += 1
+      }
+    }
+
+    Object.defineProperty(Intl, 'Segmenter', {
+      configurable: true,
+      writable: true,
+      value: CountingSegmenter,
+    })
+
+    const { buildFlashcardsCsv } = await loadFlashcardsModule()
+
+    await buildFlashcardsCsv(
+      [
+        'hola mundo libro',
+        'libro casa camino',
+        'camino libro hola',
+      ],
+      'es',
+      {
+        id: 'openai',
+        translateBatch: async (texts) => texts.map((text) => `en:${text}`),
+      },
+    )
+
+    expect(segmenterCreations).toBe(1)
   })
 })


### PR DESCRIPTION
## Summary
- cache the flashcard stage's `Intl.Segmenter` and stopword `Set` once per language instead of rebuilding them for every paragraph
- add a focused Vitest case that fails if paragraph scanning starts recreating segmenters again
- document the tokenizer reuse contract in the README and test plan

## Why
Translation API time still dominates the overall workflow, but every successful job also runs a local flashcard pass over the translated text. On long books that pass was repeatedly allocating the same tokenizer helpers for each paragraph even though the language never changes within the stage.

## Impact
This keeps flashcard output behavior the same while removing avoidable CPU and allocation churn from the final stage of each completed job.

## Validation
- `npm test`
- `npm run build`
