### PR TITLE
[codex] Pause hidden job polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,5 @@ https://<your-domain>/api/healthz
 
 - `POST /api/jobs` validates file type, file size, blob path, and target language before inserting a job.
 - Page-count, encrypted-PDF, and image-only checks run inside the `parse_pdf` workflow stage so job creation stays fast and does not re-read the uploaded PDF twice.
+- The home page pauses `/api/jobs/:id` polling while the tab is hidden, then refreshes once immediately when the page becomes visible again. See [docs/job-status-polling.md](docs/job-status-polling.md).
 - The legacy `backend/` and `frontend/` directories are no longer part of the runtime path.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import { DownloadCard } from '@/components/DownloadCard'
 import { ProgressFeed, type JobStatus } from '@/components/ProgressFeed'
 import { TargetLangSelect } from '@/components/TargetLangSelect'
 import { UploadBox } from '@/components/UploadBox'
+import { isTerminalJobStatus, shouldPollJobStatus } from '@/lib/job-polling'
 
 const POLL_INTERVAL_MS = 2000
 
@@ -22,31 +23,71 @@ export default function HomePage() {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const isProcessing =
-    jobStatus !== null && !['done', 'error'].includes(jobStatus.status) && !error
+  const isProcessing = jobStatus !== null && !isTerminalJobStatus(jobStatus.status) && !error
 
   useEffect(() => {
-    if (!jobStatus?.job_id || ['done', 'error'].includes(jobStatus.status)) {
+    if (!jobStatus?.job_id || isTerminalJobStatus(jobStatus.status) || error) {
       return
     }
 
-    const interval = window.setInterval(async () => {
+    const jobId = jobStatus.job_id
+    let interval: number | null = null
+    let cancelled = false
+
+    async function refreshJobStatus() {
       try {
-        const response = await fetch(`/api/jobs/${jobStatus.job_id}`)
+        const response = await fetch(`/api/jobs/${jobId}`)
         if (!response.ok) {
           throw new Error('Unable to refresh job status.')
         }
         const payload = (await response.json()) as JobStatus
+        if (cancelled) {
+          return
+        }
+
         setJobStatus(payload)
+        if (isTerminalJobStatus(payload.status) && interval !== null) {
+          window.clearInterval(interval)
+          interval = null
+        }
       } catch (refreshError) {
         console.error(refreshError)
         setError('Something went wrong while tracking progress. Please refresh to continue.')
+        if (interval !== null) {
+          window.clearInterval(interval)
+          interval = null
+        }
+      }
+    }
+
+    function syncPollingToVisibility() {
+      if (!shouldPollJobStatus(jobStatus, false, document.visibilityState)) {
+        if (interval !== null) {
+          window.clearInterval(interval)
+          interval = null
+        }
+        return
+      }
+
+      if (interval === null) {
+        void refreshJobStatus()
+        interval = window.setInterval(() => {
+          void refreshJobStatus()
+        }, POLL_INTERVAL_MS)
+      }
+    }
+
+    syncPollingToVisibility()
+    document.addEventListener('visibilitychange', syncPollingToVisibility)
+
+    return () => {
+      cancelled = true
+      if (interval !== null) {
         window.clearInterval(interval)
       }
-    }, POLL_INTERVAL_MS)
-
-    return () => window.clearInterval(interval)
-  }, [jobStatus?.job_id, jobStatus?.status])
+      document.removeEventListener('visibilitychange', syncPollingToVisibility)
+    }
+  }, [error, jobStatus?.job_id, jobStatus?.status])
 
   async function createJob() {
     if (!selectedFile) {

--- a/docs/job-status-polling.md
+++ b/docs/job-status-polling.md
@@ -1,0 +1,15 @@
+# Hidden-Tab Job Polling
+
+Job progress is fetched from `GET /api/jobs/:id` every two seconds while a translation is in flight. That polling is useful only when the user can actually see the progress card.
+
+## Optimization Rule
+
+- Keep the existing polling cadence while the document is visible.
+- Pause polling completely when the tab is hidden.
+- Trigger one immediate refresh when the tab becomes visible again so the UI catches up without waiting for the next two-second tick.
+
+## Why This Exists
+
+Long translations can run for minutes. If the user switches tabs during that time, the old behavior keeps issuing identical progress requests against the API and database even though nobody can see the updates.
+
+This optimization is intentionally narrow: it reduces hidden-tab request volume without changing the progress payload, the public API surface, or the visible polling cadence while the page is on screen.

--- a/lib/job-polling.ts
+++ b/lib/job-polling.ts
@@ -1,0 +1,13 @@
+export function isTerminalJobStatus(
+  status: string | null | undefined,
+): boolean {
+  return status === 'done' || status === 'error'
+}
+
+export function shouldPollJobStatus(
+  status: { job_id: string; status: string } | null,
+  hasError: boolean,
+  visibilityState: DocumentVisibilityState,
+): boolean {
+  return visibilityState === 'visible' && Boolean(status?.job_id) && !hasError && !isTerminalJobStatus(status?.status)
+}

--- a/tests/job-polling.test.ts
+++ b/tests/job-polling.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { isTerminalJobStatus, shouldPollJobStatus } from '../lib/job-polling'
+
+describe('job polling helpers', () => {
+  it('treats done and error states as terminal', () => {
+    expect(isTerminalJobStatus('done')).toBe(true)
+    expect(isTerminalJobStatus('error')).toBe(true)
+    expect(isTerminalJobStatus('processing')).toBe(false)
+  })
+
+  it('polls only visible active jobs without client-side errors', () => {
+    expect(
+      shouldPollJobStatus(
+        {
+          job_id: 'job_123',
+          status: 'processing',
+        },
+        false,
+        'visible',
+      ),
+    ).toBe(true)
+
+    expect(
+      shouldPollJobStatus(
+        {
+          job_id: 'job_123',
+          status: 'processing',
+        },
+        false,
+        'hidden',
+      ),
+    ).toBe(false)
+
+    expect(
+      shouldPollJobStatus(
+        {
+          job_id: 'job_123',
+          status: 'done',
+        },
+        false,
+        'visible',
+      ),
+    ).toBe(false)
+
+    expect(
+      shouldPollJobStatus(
+        {
+          job_id: 'job_123',
+          status: 'processing',
+        },
+        true,
+        'visible',
+      ),
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- pause `/api/jobs/:id` polling whenever the Book Translator tab is hidden
- trigger one immediate refresh when the page becomes visible again, then resume the normal two-second polling cadence
- document the hidden-tab rule and add focused helper coverage for the polling decision logic

## Why
Long translation jobs can run for minutes. The previous home-page effect kept polling the job-status endpoint every two seconds even when the user had switched away from the tab, which meant avoidable API and database reads with no visible benefit.

## Impact
This keeps the visible UX unchanged while the page is on screen, but cuts hidden-tab polling traffic to zero and catches the UI up immediately when the user returns.

## Validation
- `npx vitest run tests/job-polling.test.ts tests/flashcards.test.ts tests/pdf.test.ts`
- `npm run build`
- loaded `http://localhost:3100` in the in-app browser and verified the upload UI rendered without console errors
